### PR TITLE
Do not split on non-ascii whitespace.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -4,8 +4,15 @@ interface PolicyResult {
 
 export = (policy: string): PolicyResult => {
   const result: PolicyResult = {};
+  // Directive values are split with 1 or more ASCII whitespace characters.
+  // https://w3c.github.io/webappsec-csp/#framework-infrastructure
+  const asciiWhitespaceGreedy = /[\t\n\f\r ]+/g;
   policy.split(";").forEach((directive) => {
-    const [directiveKey, ...directiveValue] = directive.trim().split(/\s+/g);
+    // Trim trailing and leading ASCII whitespace, and split directives.
+    const [directiveKey, ...directiveValue] = directive
+      .replace(/^[\t\n\f\r ]+/, "")
+      .replace(/[\t\n\f\r ]+$/, "")
+      .split(asciiWhitespaceGreedy);
     if (
       directiveKey &&
       !Object.prototype.hasOwnProperty.call(result, directiveKey)

--- a/test.ts
+++ b/test.ts
@@ -89,6 +89,25 @@ parserTest(
 );
 
 parserTest(
+  "parse multiple valid ascii whitespace",
+  "default-src   'self'; script-src  scripts.com; default-src ",
+  {
+    "default-src": ["'self'"],
+    "script-src": ["scripts.com"],
+  },
+);
+
+parserTest(
+  "parsing directives does not split on unicode whitespace",
+  // OGHAM SPACE MARK (u1680). JS treats it as whitespace, but CSP does not.
+  "default-src 'self'; script-src scripts.com example.com",
+  {
+    "default-src": ["'self'"],
+    "script-src": ["scripts.com example.com"],
+  },
+);
+
+parserTest(
   "parsing a string with multiple directives with no spaces between semicolons",
   "default-src 'self';script-src 'unsafe-eval' scripts.com;object-src;style-src styles.biz",
   {


### PR DESCRIPTION
The routine was slightly off before, resolving some false negatives. It is possible to construct a Content Security Policy which is parsed one way by this library, but differently by user agents.

2.1 indicates that only ASCII whitespace may be treated as a separator
  between directives.
2.2.1 Parsing a serialized CSP dictates that only ASCII whitespace may
  be trimmed for CSP directives.

Therefore, we need to use exactly the right character codes, whereas the previously used \s escape code included excessive characters. Refer to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#white_space for examples.