### PR TITLE
ci: add pull request trigger and security hardening

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,10 @@ name: run tests
 on:
   push:
     branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
 
 jobs:
   test:
@@ -10,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: denoland/setup-deno@909cc5acb0fdd60627fb858598759246509fa755 # v2.0.2
         with:
           deno-version: v2.x


### PR DESCRIPTION
- Add `pull_request` trigger so CI runs on PRs, not just pushes to main
- Add top-level `permissions: contents: read` for least privilege
- Set `persist-credentials: false` on checkout step

These are GitHub Actions security best practices recommended by the [OpenSSF Scorecard](https://github.com/ossf/scorecard).