### PR TITLE
chore: move inline imports to deno.json imports map

### DIFF
--- a/build-npm.ts
+++ b/build-npm.ts
@@ -1,4 +1,4 @@
-import { build, emptyDir } from "https://deno.land/x/dnt@0.40.0/mod.ts";
+import { build, emptyDir } from "@deno/dnt";
 
 await emptyDir("./dist/npm");
 

--- a/deno.json
+++ b/deno.json
@@ -1,4 +1,8 @@
 {
+  "imports": {
+    "@std/assert": "jsr:@std/assert@^1.0.19",
+    "@deno/dnt": "jsr:@deno/dnt@^0.42.3"
+  },
   "tasks": {
     "npm": "deno run -A build-npm.ts",
     "clean": "rm -rf dist",

--- a/deno.lock
+++ b/deno.lock
@@ -1,5 +1,21 @@
 {
-  "version": "3",
+  "version": "5",
+  "specifiers": {
+    "jsr:@std/assert@*": "1.0.19",
+    "jsr:@std/assert@^1.0.19": "1.0.19",
+    "jsr:@std/internal@^1.0.12": "1.0.12"
+  },
+  "jsr": {
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/internal@1.0.12": {
+      "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
+    }
+  },
   "remote": {
     "https://deno.land/std@0.140.0/_util/assert.ts": "e94f2eb37cebd7f199952e242c77654e43333c1ac4c5c700e929ea3aa5489f74",
     "https://deno.land/std@0.140.0/_util/os.ts": "3b4c6e27febd119d36a416d7a97bd3b0251b77c88942c8f16ee5953ea13e2e49",
@@ -113,5 +129,11 @@
     "https://deno.land/x/wasmbuild@0.14.1/loader.ts": "d98d195a715f823151cbc8baa3f32127337628379a02d9eb2a3c5902dbccfc02",
     "https://deno.land/x/wasmbuild@0.15.1/cache.ts": "9d01b5cb24e7f2a942bbd8d14b093751fa690a6cde8e21709ddc97667e6669ed",
     "https://deno.land/x/wasmbuild@0.15.1/loader.ts": "8c2fc10e21678e42f84c5135d8ab6ab7dc92424c3f05d2354896a29ccfd02a63"
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@deno/dnt@~0.42.3",
+      "jsr:@std/assert@^1.0.19"
+    ]
   }
 }

--- a/test.ts
+++ b/test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.215.0/assert/mod.ts";
+import { assertEquals } from "@std/assert";
 import parse from "./mod.ts";
 
 type TestCase = {


### PR DESCRIPTION
Move inline import specifiers to the \`deno.json\` imports map:
- \`test.ts\`: \`https://deno.land/std@0.215.0/assert/mod.ts\` -> \`@std/assert\` (via JSR)
- \`build-npm.ts\`: \`https://deno.land/x/dnt@0.40.0/mod.ts\` -> \`@deno/dnt\` (via JSR)

This fixes 3 Deno lint errors:
- \`no-import-prefix\`: Inline \`https:\`/\`jsr:\` dependency not allowed
- \`no-unversioned-import\`: Missing version in specifier

The old \`deno.land/x\` and \`deno.land/std\` URLs are legacy — JSR (\`jsr.io\`) is the recommended package registry for Deno 2.

All 9 tests pass, lint and fmt are clean.