### PR TITLE
fix: remove duplicate "security" keyword

### DIFF
--- a/build-npm.ts
+++ b/build-npm.ts
@@ -13,7 +13,7 @@ await build({
     description: "Parse Content Security Policy directives.",
     version: "0.6.0",
     license: "MIT",
-    keywords: ["security", "content", "security", "policy", "csp", "parser"],
+    keywords: ["content", "security", "policy", "csp", "parser"],
     homepage: "https://github.com/helmetjs/content-security-policy-parser",
     repository: {
       type: "git",


### PR DESCRIPTION
The npm package keywords array in \`build-npm.ts\` has \`\"security\"\` listed twice:

\`\`\`js
keywords: ["security", "content", "security", "policy", "csp", "parser"],
//                       duplicate ^^^^^^^^^^
\`\`\`

This removes the duplicate.